### PR TITLE
SIM-2797: Let LLM==None fall through to SAGA itself instead of the Se…

### DIFF
--- a/fable_saga/server.py
+++ b/fable_saga/server.py
@@ -60,8 +60,6 @@ class SagaServer:
     """ Server for SAGA. """
     def __init__(self, llm: BaseLanguageModel = None):
         super().__init__()
-        if llm is None:
-            llm = fable_saga.ChatOpenAI()
         self.agent = fable_saga.Agent(llm)
 
     async def generate_actions(self, req: ActionsRequest) -> ActionsResponse:
@@ -90,6 +88,7 @@ if __name__ == '__main__':
     args = parser.parse_args()
 
     # Create common server objects
+    # Note: This is where you could override the LLM by passing the llm parameter to SagaServer.
     server = SagaServer()
     app = web.Application()
 


### PR DESCRIPTION
…rver.

* Handling the default meant we were not using the best model currently available and not able to use the JSON parameter to ensure better results.
* Currently the best 3.5 model is gpt-3.5-turbo-1106 which allows for a much larger context window at 16k vs just 4k in the current default, which is supposed to change soon.
* Add a note about where one could override the llm used in server.py.
* It might make sense to allow this to be overridden per request or as a command argument later.