### PR TITLE
SIM-2879: Refactor the server and get mocking working again with generics.

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,9 +139,9 @@ memories and the like in your context data, but don't want to send the entire te
 provides embeddings, but will also store documents and find similar documents based on the embedding of a query you
 provide. This is useful for finding similar memories, personas, etc.
 
-Right now, there is only a single index that uses sklearn's NearestNeighbors to find similar documents. This is not
-very scalable, but it's a good starting point and it uses OpenAI's embeddings, which are very good. Both can be swapped
-out for other systems supported by LangChain (see the `fable_saga.server` module for details).
+Right now, there is only a single index that uses a simple in-memory numpy VectorStore to find similar documents. This is not
+very scalable, but it's a good starting point and uses OpenAI's embeddings, which are very good. Both can be swapped
+out for other systems supported by LangChain (see the `fable_saga.embeddings` module for details).
 
 Also, right now there is only a single index, but it's possible to have multiple indexes soon, each with their own
 embeddings and similar documents. This is useful if you want to have different indexes for different types of
@@ -251,7 +251,7 @@ Space Colony Demo
 
 The Space Colony demo is a simple text-based simulation of a spaceship with a crew of 5 agents.
 There are various locations on the ship that the agents can move to and objects they can interact
-with. All of this data we call "Meta-Memories" and they formatted and provided to the `fable_saga.Agent`
+with. All of this data we call "Meta-Memories" and they formatted and provided to the `fable_saga.ActionsAgent`
 when requesting actions.
 
 Generating Actions from Skills
@@ -281,7 +281,7 @@ It's important to note that SAGA itself doesn't know how to drive the simulation
 is left to the simulation itself. SAGA only knows how to generate actions based on the skills you
 provide it. You can add more skills to the demo for instance, and SAGA will be able to generate
 actions for them, but you will have to implement the logic for those actions in the demo simulation.
-You can also use the `fable_saga.Agent` class outside the demo to generate actions for your own sim. 
+You can also use the `fable_saga.ActionsAgent` class outside the demo to generate actions for your own sim. 
 This demo just makes it easy to see how the agents use these skills to generate actions.
 
 Skills are used by SAGA to generate Action options. In the demo, they are returned to you interactively
@@ -318,11 +318,14 @@ Memories
 -------------
 As the agents move around the ship and interact with objects and other agents, they generate memories
 of those interactions. These memories are formatted as a list when passed in as context data to
-the `fable_saga.Agent` class. The demo simulation keeps track of these memories, not SAGA.
+the `fable_saga.ActionsAgent` and `fable_saga.ConversationAgent` classese. The demo simulation keeps track of these memories, not SAGA.
 
 The memories will continue to be generated as the agents interact with the world. This can add a lot of
 tokens to the context data, so if you have any intention of running the demo for a long time, you will
 want to implement some kind of memory management system to keep the context data from getting too large.
+
+Since there isn't a memory management system in place, the demo simulation will eventually run out of context tokens
+depending on the model you are using. The default model is `gpt-3.5-turbo-1106` which has a token limit of 4096 tokens.
 
 Large Language Models
 -------------

--- a/fable_saga/conversations.py
+++ b/fable_saga/conversations.py
@@ -8,8 +8,6 @@ from langchain.llms.base import BaseLanguageModel
 from langchain.prompts import load_prompt
 
 from . import (
-    logger,
-    SagaCallbackHandler,
     BaseSagaAgent,
 )
 
@@ -31,8 +29,14 @@ class GeneratedConversation:
 
 
 class ConversationAgent(BaseSagaAgent):
+    """Agent that generates conversation from a context and a list of personas."""
 
     def __init__(self, llm: Optional[BaseLanguageModel] = None):
+        """Initialize the conversation agent.
+
+        Args:
+            llm: The language model to use for generation. Defaults to OpenAI. (see LangChain docs).
+        """
         super().__init__(
             prompt_template=load_prompt(
                 pathlib.Path(__file__).parent.resolve()
@@ -49,7 +53,16 @@ class ConversationAgent(BaseSagaAgent):
         verbose=False,
         model_override: Optional[str] = None,
     ) -> GeneratedConversation:
-        """Generate conversation for the given personas and context"""
+        """Generate conversation for the given personas and context
+
+        Args:
+            persona_guids: A list of persona guids to generate conversation for. They probably match information in the
+                context.
+            context: The context to generate conversation for like character descriptions, setting, etc.
+            max_tries: The maximum number of retries to attempt if no options are found.
+            verbose: Whether to print verbose output.
+            model_override: The model to use for generation (allows for switching llm.model_name at runtime).
+        """
         assert (
             persona_guids is not None and len(persona_guids) > 0
         ), "Must provide at least one persona_guid."

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,5 +1,156 @@
-from langchain.chat_models.fake import FakeListChatModel
+import asyncio
+import json
+from functools import partial
+from pathlib import Path
+from typing import List, Callable, Optional, Awaitable, TypeVar, Type, cast, Generic
+from unittest import mock
+
+import pytest
+from cattr import structure
+from cattrs import structure
+from langchain.embeddings.fake import DeterministicFakeEmbedding
+from langchain_community.llms.fake import FakeListLLM
+from langchain_core.language_models import BaseLanguageModel
+
+import fable_saga.embeddings as saga_embed
+from fable_saga.actions import Skill, ActionsAgent
+from fable_saga.conversations import ConversationAgent
+from fable_saga.embeddings import EmbeddingAgent
+from fable_saga.server import (
+    ActionsRequest,
+    ConversationRequest,
+    BaseEndpoint,
+    ActionsResponse,
+    get_generic_types,
+    TReq,
+    TResp,
+)
+
+path = Path(__file__).parent
+
+# T is a type variable that is bound to BaseEndpoint or its subclasses.
+TEndpoint = TypeVar("TEndpoint", bound=BaseEndpoint, covariant=True)
 
 
-class FakeChatOpenAI(FakeListChatModel):
-    model_name: str = "model_name_default"
+class FakeOpenAI(FakeListLLM, BaseLanguageModel):
+    model_name = "unchanged"
+
+    def __init__(self, responses: List[str], sleep: float = 0):
+        FakeListLLM.__init__(self, responses=responses, sleep=sleep)
+
+
+@pytest.fixture
+def fake_actions_llm() -> FakeOpenAI:
+    actions = json.load(open(path / "examples/generated_actions.json"))
+    responses = [json.dumps(action) for action in actions]
+    llm = FakeOpenAI(responses=responses, sleep=0.1)
+    return llm
+
+
+@pytest.fixture
+def fake_skills() -> list[Skill]:
+    skills_data = json.load(open(path / "examples/skills.json"))
+    skills = [structure(skill_data, Skill) for skill_data in skills_data]
+    return skills
+
+
+@pytest.fixture
+def fake_actions_request() -> ActionsRequest:
+    request_data = json.load(open(path / "examples/actions_request.json"))
+    req = structure(request_data, ActionsRequest)
+    return req
+
+
+@pytest.fixture
+def fake_conversation_llm():
+    conversations = json.load(open(path / "examples/generated_conversation.json"))
+    responses = [json.dumps(conversation) for conversation in conversations]
+    llm = FakeOpenAI(responses=responses, sleep=0.1)
+    return llm
+
+
+@pytest.fixture
+def fake_conversation_request():
+    request_data = json.load(open(path / "examples/conversation_request.json"))
+    req = structure(request_data, ConversationRequest)
+    return req
+
+
+@pytest.fixture
+def fake_embedding_model():
+    class FakeAsyncEmbeddingModel(DeterministicFakeEmbedding):
+
+        async def aembed_documents(self, texts: List[str]):
+            func = partial(self.embed_documents, texts)
+            return await asyncio.get_event_loop().run_in_executor(None, func)
+
+        async def aembed_query(self, text: str):
+            func = partial(self.embed_query, text)
+            return await asyncio.get_event_loop().run_in_executor(None, func)
+
+        def _select_relevance_score_fn(self, query: str):
+            return lambda x: 0.5
+
+    return FakeAsyncEmbeddingModel(size=1536)
+
+
+@pytest.fixture
+def fake_documents():
+    data = json.load(open(path / "examples/embedding_documents.json"))
+    documents = [saga_embed.Document(**doc) for doc in data["documents"]]
+    return documents
+
+
+@pytest.fixture
+def fake_actions_agent(fake_actions_llm) -> ActionsAgent:
+    return ActionsAgent(fake_actions_llm)
+
+
+@pytest.fixture
+def fake_conversation_agent(
+    fake_conversation_llm,
+) -> ConversationAgent:
+    return ConversationAgent(fake_conversation_llm)
+
+
+@pytest.fixture
+def fake_embedding_agent(fake_embedding_model) -> EmbeddingAgent:
+    return EmbeddingAgent(fake_embedding_model)
+
+
+class EndpointMocker(Generic[TEndpoint]):
+
+    def __init__(
+        self,
+        cls: Type[TEndpoint],
+        override_handler: Optional[
+            Callable[[TEndpoint, TReq], Awaitable[TResp]]
+        ] = None,
+    ):
+        assert issubclass(cls, BaseEndpoint)
+        self.cls = cls
+        self.override_handler = override_handler
+        self.original_handle_request = cls.handle_request
+
+    def __enter__(self) -> Type[TEndpoint]:
+
+        req_type, resp_type = get_generic_types(self.cls)
+
+        if self.override_handler:
+            setattr(
+                self.cls,
+                "handle_request",
+                mock.create_autospec(
+                    self.cls.handle_request, side_effect=self.override_handler
+                ),
+            )
+        else:
+            setattr(
+                self.cls,
+                "handle_request",
+                mock.create_autospec(self.cls.handle_request, return_value=resp_type()),
+            )
+        return self.cls
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        setattr(self.cls, "handle_request", self.original_handle_request)

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -2,9 +2,10 @@ import asyncio
 import json
 from functools import partial
 from pathlib import Path
-from typing import List, Callable, Optional, Awaitable, TypeVar, Type, cast, Generic
+from typing import List, Callable, Optional, Awaitable, TypeVar, Type, Generic
 from unittest import mock
 
+# noinspection PyPackageRequirements
 import pytest
 from cattr import structure
 from cattrs import structure
@@ -20,7 +21,6 @@ from fable_saga.server import (
     ActionsRequest,
     ConversationRequest,
     BaseEndpoint,
-    ActionsResponse,
     get_generic_types,
     TReq,
     TResp,
@@ -78,6 +78,7 @@ def fake_conversation_request():
 
 @pytest.fixture
 def fake_embedding_model():
+    # noinspection SpellCheckingInspection
     class FakeAsyncEmbeddingModel(DeterministicFakeEmbedding):
 
         async def aembed_documents(self, texts: List[str]):
@@ -88,7 +89,8 @@ def fake_embedding_model():
             func = partial(self.embed_query, text)
             return await asyncio.get_event_loop().run_in_executor(None, func)
 
-        def _select_relevance_score_fn(self, query: str):
+        # noinspection PyMethodMayBeStatic
+        def _select_relevance_score_fn(self, _: str):
             return lambda x: 0.5
 
     return FakeAsyncEmbeddingModel(size=1536)

--- a/tests/test_actions.py
+++ b/tests/test_actions.py
@@ -1,5 +1,6 @@
 import json
 
+# noinspection PyPackageRequirements
 import pytest
 from cattr import unstructure
 

--- a/tests/test_actions.py
+++ b/tests/test_actions.py
@@ -1,33 +1,10 @@
 import json
 
 import pytest
-from cattr import unstructure, structure
+from cattr import unstructure
 
-from fable_saga.actions import ActionsAgent, Skill
-from fable_saga.server import ActionsRequest
-from . import FakeChatOpenAI
-
-
-@pytest.fixture
-def fake_actions_llm() -> FakeChatOpenAI:
-    actions = json.load(open("examples/generated_actions.json"))
-    responses = [json.dumps(action) for action in actions]
-    llm = FakeChatOpenAI(responses=responses, sleep=0.1)
-    return llm
-
-
-@pytest.fixture
-def fake_skills() -> list[Skill]:
-    skills_data = json.load(open("examples/skills.json"))
-    skills = [structure(skill_data, Skill) for skill_data in skills_data]
-    return skills
-
-
-@pytest.fixture
-def fake_actions_request() -> ActionsRequest:
-    request_data = json.load(open("examples/actions_request.json"))
-    req = structure(request_data, ActionsRequest)
-    return req
+from fable_saga.actions import ActionsAgent
+from . import fake_actions_llm, fake_skills
 
 
 class TestSagaAgent:
@@ -75,7 +52,7 @@ class TestSagaAgent:
         # Note: We don't add the "Human: " prefix in the test data, LangChain does that.
         assert actions.raw_prompt is not None
         assert actions.raw_prompt.startswith(
-            "Human: Generate a list of different action options that your character"
+            "Generate a list of different action options that your character"
             " should take next using the following skills:"
         )
 

--- a/tests/test_conversations.py
+++ b/tests/test_conversations.py
@@ -1,3 +1,4 @@
+# noinspection PyPackageRequirements
 import pytest
 
 import fable_saga

--- a/tests/test_conversations.py
+++ b/tests/test_conversations.py
@@ -1,37 +1,11 @@
-import json
-from typing import List
-
 import pytest
-from cattrs import structure
-from langchain.llms.base import BaseLanguageModel
-from langchain.llms.fake import FakeListLLM
 
 import fable_saga
 import fable_saga.conversations
-from fable_saga.server import ConversationRequest
+from tests import fake_conversation_llm
 
 
 # Create a fake OpenAI model that inherits from the FakeListLLM and ChatOpenAI classes.
-class FakeOpenAI(FakeListLLM, BaseLanguageModel):
-    model_name = "unchanged"
-
-    def __init__(self, responses: List[str], sleep: float = 0):
-        FakeListLLM.__init__(self, responses=responses, sleep=sleep)
-
-
-@pytest.fixture
-def fake_conversation_llm():
-    conversations = json.load(open("examples/generated_conversation.json"))
-    responses = [json.dumps(conversation) for conversation in conversations]
-    llm = FakeOpenAI(responses=responses, sleep=0.1)
-    return llm
-
-
-@pytest.fixture
-def fake_conversation_request():
-    request_data = json.load(open("examples/conversation_request.json"))
-    req = structure(request_data, ConversationRequest)
-    return req
 
 
 class TestConversationAgent:

--- a/tests/test_embeddings.py
+++ b/tests/test_embeddings.py
@@ -1,6 +1,8 @@
 import uuid
 
 import numpy
+
+# noinspection PyPackageRequirements
 import pytest
 from langchain.schema.embeddings import Embeddings
 

--- a/tests/test_embeddings.py
+++ b/tests/test_embeddings.py
@@ -1,40 +1,12 @@
-import asyncio
-import json
 import uuid
-from functools import partial
-from typing import List
 
 import numpy
 import pytest
-from langchain.embeddings.fake import DeterministicFakeEmbedding
 from langchain.schema.embeddings import Embeddings
 
 import fable_saga.embeddings as saga_embed
 
-
-@pytest.fixture
-def fake_embedding_model():
-    class FakeAsyncEmbeddingModel(DeterministicFakeEmbedding):
-
-        async def aembed_documents(self, texts: List[str]):
-            func = partial(self.embed_documents, texts)
-            return await asyncio.get_event_loop().run_in_executor(None, func)
-
-        async def aembed_query(self, text: str):
-            func = partial(self.embed_query, text)
-            return await asyncio.get_event_loop().run_in_executor(None, func)
-
-        def _select_relevance_score_fn(self, query: str):
-            return lambda x: 0.5
-
-    return FakeAsyncEmbeddingModel(size=1536)
-
-
-@pytest.fixture
-def fake_documents():
-    data = json.load(open("examples/embedding_documents.json"))
-    documents = [saga_embed.Document(**doc) for doc in data["documents"]]
-    return documents
+from . import fake_embedding_model, fake_documents
 
 
 class TestEmbeddingsAgent:

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -4,6 +4,8 @@ from typing import Dict, cast
 from unittest.mock import AsyncMock, patch
 
 import cattrs
+
+# noinspection PyPackageRequirements
 import pytest
 from cattr import unstructure
 
@@ -15,6 +17,7 @@ import fable_saga.server
 from fable_saga import server
 
 # This line is needed to import BEFORE the other fixtures because otherwise they aren't found for some reason.
+# noinspection PyUnresolvedReferences
 from . import (
     fake_actions_llm,
     fake_conversation_llm,
@@ -133,7 +136,7 @@ class TestEmbeddingServer:
         # noinspection PyTypeChecker
         request = server.EmbeddingsRequest(texts=1)  # type: ignore
         with pytest.raises(TypeError, match="'int' object is not iterable"):
-            response = await endpoint.handle_request(request)
+            await endpoint.handle_request(request)
 
     @pytest.mark.asyncio
     async def test_add_documents(self, fake_embedding_agent, fake_documents):
@@ -203,7 +206,10 @@ class TestGenericHandler:
             missing_data: Dict = {}
             with EndpointMocker(server.ActionsEndpoint) as mock:
                 endpoint = mock(fake_actions_agent)
-                expected_error = 'Error validating request: ["required field missing @ $.context", "required field missing @ $.skills"]'
+                expected_error = (
+                    'Error validating request: ["required field missing @ $.context", "required field '
+                    'missing @ $.skills"]'
+                )
 
                 if server.throw_exceptions:
                     with pytest.raises(
@@ -255,7 +261,7 @@ class TestGenericHandler:
         expected_request = server.ActionsRequest(context="context", skills=fake_skills)
         fake_data = {"context": "context", "skills": unstructure(fake_skills)}
 
-        async def fake_handler(*args) -> server.ActionsResponse:
+        async def fake_handler(*_) -> server.ActionsResponse:
             return server.ActionsResponse(
                 actions=fable_saga.actions.GeneratedActions(
                     options=[fable_saga.actions.Action("some_skill")], scores=[1]

--- a/tests/test_space_colony.py
+++ b/tests/test_space_colony.py
@@ -1,6 +1,7 @@
 import datetime
 from unittest.mock import Mock
 
+# noinspection PyPackageRequirements
 import pytest
 
 import fable_saga

--- a/tests/test_space_colony.py
+++ b/tests/test_space_colony.py
@@ -11,8 +11,7 @@ from fable_saga.demos.space_colony.simulation import (
     ActionGenerator,
     ConversationGenerator,
 )
-from .test_conversations import fake_conversation_llm
-from .test_actions import fake_actions_llm, FakeChatOpenAI
+from . import fake_actions_llm, fake_conversation_llm, FakeOpenAI
 
 
 @pytest.fixture
@@ -27,7 +26,7 @@ def fake_conversation_agent(fake_conversation_llm):
 
 @pytest.fixture
 def fake_chat_openai():
-    return FakeChatOpenAI(responses=[], sleep=0.1)
+    return FakeOpenAI(responses=[], sleep=0.1)
 
 
 class TestSimulation:
@@ -113,7 +112,7 @@ class TestSimulation:
     @pytest.mark.asyncio
     async def test_simulation_tick(self, fake_conversation_agent, fake_chat_openai):
 
-        goto_bridge_llm = FakeChatOpenAI(
+        goto_bridge_llm = FakeOpenAI(
             responses=[
                 """{"options": [
                 {"skill": "go_to", "parameters": {"destination": "bridge", "goal": "get to the bridge"}},
@@ -144,7 +143,7 @@ class TestSimulation:
     @pytest.mark.asyncio
     async def test_go_to(self, fake_conversation_llm, fake_chat_openai):
 
-        goto_bridge_llm = FakeChatOpenAI(
+        goto_bridge_llm = FakeOpenAI(
             responses=[
                 """{"options": [
                 {"skill": "go_to", "parameters": {"destination": "bridge", "goal": "get to the bridge"}},


### PR DESCRIPTION
* Main goal here was to cut down on boilerplate while preserving type safety.
* Use Generics and a custom get_generic_types() as as way to specify the request and return types an endpoint should expect and then use those types for instancing those types in the generic_handler()
* This also makes it easier to mock the Endpoints at test time.
* Added runtime verification of the types helps prevent mistakes.
* (*Server) types are now (*Endpoint) types basically. They now have a consistent handle_respsone(TReq)->TResp method, cutting down the boilerplate you have to write for each one.
* EndpointMocker() helper makes it easy to wrap the existing handler in a mock and return a TResp() or to add in an override_handler param and provide your own at test time.
* server.throw_exceptions is now a global to decide if the generic_handler() should gracefully handle errors by adding the error to the return value or to rethrow the actual exception.