### PR TITLE
SIM-2922: Re-format the conversation prompt

### DIFF
--- a/fable_saga/conversations.py
+++ b/fable_saga/conversations.py
@@ -13,14 +13,8 @@ from . import (
 
 
 @define(slots=True)
-class ConversationTurn:
-    persona_guid: str
-    dialogue: str
-
-
-@define(slots=True)
 class GeneratedConversation:
-    conversation: List[ConversationTurn]
+    conversation: List[Dict[str, str]]
     raw_prompt: Optional[str] = None
     raw_response: Optional[str] = None
     llm_info: Optional[Dict[str, Any]] = None

--- a/fable_saga/demos/space_colony/sim_actions.py
+++ b/fable_saga/demos/space_colony/sim_actions.py
@@ -190,7 +190,10 @@ class ConverseWith(SimAction):
         if generated_conversation.error is None:
             conversation_formatted = "Dialogue:\n"
             for turn in generated_conversation.conversation:
-                conversation_formatted += f"\t{turn.persona_guid}: {turn.dialogue}\n"
+                for persona_guid in turn:
+                    conversation_formatted += (
+                        f"\t{persona_guid}: {turn[persona_guid]}\n"
+                    )
 
             self.agent.memories.append(
                 sim_models.Memory(

--- a/fable_saga/prompt_templates/generate_conversation.yaml
+++ b/fable_saga/prompt_templates/generate_conversation.yaml
@@ -8,5 +8,5 @@ template: |
     Only generate valid JSON.
     Use the following JSON format to construct the conversation:
             {{"conversation": [
-                {{"persona_guid": <str: identifier of the speaking character>, "dialogue": <str: the line of dialogue spoken>
+                {{<str: identifier of the speaking character>, <str: the line of dialogue spoken>
             ]}}

--- a/tests/examples/generated_conversation.json
+++ b/tests/examples/generated_conversation.json
@@ -2,12 +2,10 @@
   {
     "conversation": [
       {
-        "persona_guid": "person_a",
-        "dialogue": "person_a_dialogue"
+        "person_a": "person_a_dialogue"
       },
       {
-        "persona_guid": "person_b",
-        "dialogue": "person_b_dialogue"
+        "person_b": "person_b_dialogue"
       }
     ]
   }

--- a/tests/test_conversations.py
+++ b/tests/test_conversations.py
@@ -39,10 +39,8 @@ class TestConversationAgent:
 
         # Validate conversation output
         assert len(response.conversation) == 2
-        assert response.conversation[0].persona_guid == "person_a"
-        assert response.conversation[0].dialogue == "person_a_dialogue"
-        assert response.conversation[1].persona_guid == "person_b"
-        assert response.conversation[1].dialogue == "person_b_dialogue"
+        assert response.conversation[0]["person_a"] == "person_a_dialogue"
+        assert response.conversation[1]["person_b"] == "person_b_dialogue"
 
         # Check that the prompt starts with the right text.
         # Note: We don't add the "Human: " prefix in the test data, LangChain does that.

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -107,10 +107,8 @@ class TestConversationEndpoint:
         # Validate conversation data
         conversation = response.conversation.conversation
         assert len(conversation) == 2
-        assert conversation[0].persona_guid == "person_a"
-        assert conversation[0].dialogue == "person_a_dialogue"
-        assert conversation[1].persona_guid == "person_b"
-        assert conversation[1].dialogue == "person_b_dialogue"
+        assert conversation[0]["person_a"] == "person_a_dialogue"
+        assert conversation[1]["person_b"] == "person_b_dialogue"
 
 
 class TestEmbeddingServer:


### PR DESCRIPTION
Re-format the conversation prompt to use a Dict[persona_id, dialogue] instead of using an object with parameters.