### PR TITLE
SIM-2920: Manually create llm_info when streaming openAI models.

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -12,3 +12,6 @@ ignore_missing_imports = True
 
 [mypy-torch]
 ignore_missing_imports = True
+
+[mypy-tiktoken]
+ignore_missing_imports = True


### PR DESCRIPTION
* When you enable streaming for openAI, it stops returning the llm_info in the response, so we have to recreate the model and token information ourselves.
* See https://github.com/langchain-ai/langchain/issues/13430.